### PR TITLE
EPA-239: Bump ePA-lib dependencies

### DIFF
--- a/epa4all-rest-service/pom.xml
+++ b/epa4all-rest-service/pom.xml
@@ -21,7 +21,7 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured-bom</artifactId>
-        <version>5.5.1</version>
+        <version>6.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <xml.bind.jaxb.version>2.3.1</xml.bind.jaxb.version>
     <jaxb.fluent.api.version>3.0</jaxb.fluent.api.version>
     <bouncycastle.version>1.81</bouncycastle.version>
-    <logback-classic.version>1.5.18</logback-classic.version>
+    <logback-classic.version>1.5.22</logback-classic.version>
 
     <sonar.organization>oviva-ag</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -100,19 +100,19 @@
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-impl</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.6</version>
       </dependency>
 
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
-        <version>1.18.34</version>
+        <version>1.18.42</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
-        <version>4.9.3</version>
+        <version>4.9.8</version>
         <exclusions>
           <exclusion>
             <groupId>com.google.code.findbugs</groupId>
@@ -158,30 +158,30 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.19.0</version>
+        <version>2.20.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.nimbusds</groupId>
         <artifactId>nimbus-jose-jwt</artifactId>
-        <version>10.3</version>
+        <version>10.6</version>
       </dependency>
       <dependency>
         <groupId>com.nimbusds</groupId>
         <artifactId>oauth2-oidc-sdk</artifactId>
-        <version>11.25</version>
+        <version>11.30.1</version>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-api</artifactId>
-        <version>1.50.0</version>
+        <version>1.57.0</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.18.0</version>
+        <version>3.20.0</version>
       </dependency>
 
       <dependency>
@@ -193,13 +193,13 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.27.3</version>
+        <version>3.27.6</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-bom</artifactId>
-        <version>5.18.0</version>
+        <version>5.21.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -207,7 +207,7 @@
       <dependency>
         <groupId>io.undertow</groupId>
         <artifactId>undertow-core</artifactId>
-        <version>2.3.18.Final</version>
+        <version>2.3.20.Final</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrade multiple dependency versions in root `pom.xml` and update `rest-assured-bom` to 6.0.0 in `epa4all-rest-service/pom.xml`.
> 
> - **Dependency upgrades (root `pom.xml`)**:
>   - `logback-classic` property: `1.5.18` → `1.5.22`.
>   - `dependencyManagement`:
>     - `com.sun.xml.bind:jaxb-impl`: `4.0.5` → `4.0.6`.
>     - `org.projectlombok:lombok`: `1.18.34` → `1.18.42`.
>     - `com.github.spotbugs:spotbugs-annotations`: `4.9.3` → `4.9.8`.
>     - `com.fasterxml.jackson:jackson-bom`: `2.19.0` → `2.20.1`.
>     - `com.nimbusds:nimbus-jose-jwt`: `10.3` → `10.6`.
>     - `com.nimbusds:oauth2-oidc-sdk`: `11.25` → `11.30.1`.
>     - `io.opentelemetry:opentelemetry-api`: `1.50.0` → `1.57.0`.
>     - `org.apache.commons:commons-lang3`: `3.18.0` → `3.20.0`.
>     - `org.assertj:assertj-core`: `3.27.3` → `3.27.6` (test).
>     - `org.mockito:mockito-bom`: `5.18.0` → `5.21.0` (test BOM).
>     - `io.undertow:undertow-core`: `2.3.18.Final` → `2.3.20.Final`.
> - **Rest service (`epa4all-rest-service/pom.xml`)**:
>   - `io.rest-assured:rest-assured-bom`: `5.5.1` → `6.0.0` (imported BOM).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5dcf29ffdfb4fb8bae3494bef15946977c742b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->